### PR TITLE
chore: Deploy

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: sekun
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    name: Build release and deploy
+    runs-on: ubuntu-20.04
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup local database
+        run: |
+          createdb emojied_db && \
+          nix develop .#devShells.x86_64-linux.ci \
+            --command sqitch deploy
+
+      - name: Build server
+        run: |
+          docker run \
+            --network=host \
+            --rm -it \
+            -v "$(pwd)":/home/rust/src ekidd/rust-musl-builder \
+            cargo build --release
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost/emojied_db
+
+      - name: Send off to Fly.io
+        uses: superfly/flyctl-actions@1.3
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        with:
+          args: "deploy --local-only"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM alpine:3.14.0 AS assets
+
+ENV TAILWIND_VERSION=3.0.23
+ENV TAILWIND_URL=https://github.com/tailwindlabs/tailwindcss/releases/download/v${TAILWIND_VERSION}/tailwindcss-linux-x64
+
+ENV ESBUILD_VERSION=0.14.27
+ENV ESBUILD_URL=https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-${ESBUILD_VERSION}.tgz
+
+WORKDIR /app
+
+# Download Tailwind
+RUN \
+    apk add curl && \
+    curl -sL ${TAILWIND_URL} -o /usr/bin/tailwindcss && \
+     chmod +x /usr/bin/tailwindcss
+
+# Download esbuild
+RUN \
+    apk add curl && \
+    curl ${ESBUILD_URL} | tar xvz && \
+     mv ./package/bin/esbuild /usr/bin/esbuild && \
+     chmod +x /usr/bin/esbuild
+
+# Copy emojied template
+# Need this because Tailwind purges the classes in the template. So, without it,
+# only the default styles will remain.
+COPY src src
+
+# Copy swoogle static files
+COPY assets assets
+COPY public public
+
+RUN apk add tree
+
+RUN tree .
+
+# Build and minify stylesheet
+RUN \
+    tailwindcss \
+      --input assets/app.css \
+      --output public/app.css \
+      --config assets/tailwind.config.js \
+      --minify
+
+# Build and minify *S
+RUN \
+    esbuild assets/app.ts \
+      --outfile=public/app.js \
+      --minify
+
+################################################################################
+
+FROM alpine:3.14.0
+
+WORKDIR /app
+
+RUN chown nobody /app
+
+COPY --chown=nobody:root target/x86_64-unknown-linux-musl/release/emojied emojied
+COPY --from=assets --chown=nobody:root /app/public public
+
+EXPOSE 3000
+
+CMD ["/app/emojied"]

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,12 @@
         #     };
         #   };
         # };
+        devShells.ci = pkgs.mkShell rec {
+          buildInputs = [
+            pkgs.sqitchPg
+            pkgs.perl534Packages.TAPParserSourceHandlerpgTAP
+          ];
+        };
 
         devShell = pkgs.mkShell {
           # inherit (self.checks.${system}.pre-commit-check) shellHook;
@@ -49,6 +55,7 @@
             pkgs.clippy
             pkgs.rustfmt
             pkgs.cargo-watch
+            pkgs.flyctl
           ];
         };
       });

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,40 @@
+# fly.toml file generated for emojied on 2022-04-04T16:01:32+08:00
+
+app = "emojied"
+
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <noscript class="foo">
+      Hello
+    </noscript>
+
+    <noscript>
+      <div>
+        Hello, world!
+      </div>
+    </noscript>
+
+    <noscript>
+      Boo
+    </noscript>
+  </body>
+</html>

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,5 @@
 // TODO: Use a connection pool for the DB
+// TODO: Get rid of `sqlx` for `tokio-postgres` + `deadpool-postgres` + `tokio-pg-mapper`
 
 use hyper::http::Uri;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
`sqlx`'s compile time verification is inconvenient when it comes to building a binary without any connection to the DB. So if I were to build in a Docker container, I'd have to go through more hoops just to get it to work, which is not very convenient. `query()` is also not as "good" as its macro counterparts because I get weird compiler panics for almost everything, and I can't be arsed to debug that. e.g (https://pastebin.com/raw/vPrFZcyD). Not knowing makes me less confident if I should open an internal compiler bug report.

For some reason, the type inference is not very good when it comes to `SQLx`. I get unknowns almost all the time.

So I could just use a combination of `tokio-postgres` + `deadpool-postgres` + `tokio-pg-mapper` to get the stuff I want.